### PR TITLE
[Feat] mac 스타일의 코드블럭 CSS 적용

### DIFF
--- a/src/hooks/useCodeBlockHeader.ts
+++ b/src/hooks/useCodeBlockHeader.ts
@@ -12,16 +12,21 @@ const useCodeBlockHeader = () => {
           width: 100%;
           display: flex;
           align-items: center;
+          justify-content: space-between;
           padding: 10px 14px;
           background-color: #434041;
           border-radius: 8px 8px 0 0;
+        }
+
+        .code-header .btn-group {
+          display: flex;
         }
 
         .code-header .btn {
           border-radius: 50%;
           width: 15px;
           height: 15px;
-          margin: 0 5px;
+          margin-right: 5px;
         }
 
         .code-header .btn.red {
@@ -35,6 +40,27 @@ const useCodeBlockHeader = () => {
         .code-header .btn.green {
           background-color: #43C645;
         }
+
+        .code-header .lang {
+          flex-group: 1;
+          text-align: center;
+          font-size: 14px;
+          font-weight: bold;
+        }
+
+        .code-header .copy-btn {
+          background: none;
+          border: none;
+          color: white;
+          cursor: pointer;
+          font-size: 14px;
+          font-weight: bold;
+          transition: opacity 0.2s ease-in-out;
+        }
+
+        .code-header .copy-btn:hover {
+          opacity: 0.7;
+        }
       `
       document.head.appendChild(style)
     }
@@ -42,13 +68,28 @@ const useCodeBlockHeader = () => {
     document.querySelectorAll("pre.grvsc-container").forEach((pre) => {
       if (pre.querySelector(".code-header")) return
 
+      const language = pre.getAttribute("data-language") || "text"
+
       const header = document.createElement("div")
       header.className = "code-header"
       header.innerHTML = `
-        <span class="red btn"></span>
-        <span class="yellow btn"></span>
-        <span class="green btn"></span>
+        <div class="btn-group">
+          <span class="red btn"></span>
+          <span class="yellow btn"></span>
+          <span class="green btn"></span>
+        </div>
+        <div class="lang">${language}</div>
+        <button class="copy-btn">Copy</button>
       `
+
+      const copyButton = header.querySelector(".copy-btn") as HTMLButtonElement
+      copyButton.addEventListener("click", () => {
+        const codeElement = pre.querySelector("code")
+        if (codeElement) {
+            const codeText = codeElement.innerText
+            navigator.clipboard.writeText(codeText)
+        }
+      })
 
       pre.insertBefore(header, pre.firstChild)
     })

--- a/src/hooks/useCodeBlockHeader.ts
+++ b/src/hooks/useCodeBlockHeader.ts
@@ -2,7 +2,58 @@ import { useEffect } from "react"
 
 const useCodeBlockHeader = () => {
   useEffect(() => {
-    console.log("useCodeBlockHeader useEffect 실행됨")
+    if (!document.querySelector("#code-header-style")) {
+      const style = document.createElement("style")
+      style.id = "code-header-style"
+      style.innerHTML = `
+        .code-header {
+          position: relative;
+          top: 0;
+          left: 0;
+          right: 0;
+          display: flex;
+          align-items: center;
+          padding: 10px 14px;
+          background-color: #434041;
+          border-radius: 8px 8px 0 0;
+          z-index: 10;
+        }
+
+        .code-header .btn {
+          border-radius: 50%;
+          width: 15px;
+          height: 15px;
+          margin: 0 5px;
+        }
+
+        .code-header .btn.red {
+          background-color: #F5655B;
+        }
+
+        .code-header .btn.yellow {
+          background-color: #F6BD3B;
+        }
+
+        .code-header .btn.green {
+          background-color: #43C645;
+        }
+      `
+      document.head.appendChild(style)
+    }
+
+    document.querySelectorAll("pre.grvsc-container").forEach((pre) => {
+      if (pre.previousElementSibling?.classList.contains("code-header")) return
+
+      const header = document.createElement("div")
+      header.className = "code-header"
+      header.innerHTML = `
+        <span class="red btn"></span>
+        <span class="yellow btn"></span>
+        <span class="green btn"></span>
+      `
+
+      pre.parentNode?.insertBefore(header, pre)
+    })
   }, [])
 }
 

--- a/src/hooks/useCodeBlockHeader.ts
+++ b/src/hooks/useCodeBlockHeader.ts
@@ -42,8 +42,9 @@ const useCodeBlockHeader = () => {
         }
 
         .code-header .lang {
-          flex-group: 1;
-          text-align: center;
+          position: absolute;
+          left: 50%;
+          transform: translateX(-50%);
           font-size: 14px;
           font-weight: bold;
         }

--- a/src/hooks/useCodeBlockHeader.ts
+++ b/src/hooks/useCodeBlockHeader.ts
@@ -14,7 +14,7 @@ const useCodeBlockHeader = () => {
           align-items: center;
           justify-content: space-between;
           padding: 10px 14px;
-          background-color: #434041;
+          background-color: var(--color-code-header);
           border-radius: 8px 8px 0 0;
         }
 
@@ -45,6 +45,7 @@ const useCodeBlockHeader = () => {
           position: absolute;
           left: 50%;
           transform: translateX(-50%);
+          color: var(--color-text);
           font-size: 14px;
           font-weight: bold;
         }
@@ -52,7 +53,7 @@ const useCodeBlockHeader = () => {
         .code-header .copy-btn {
           background: none;
           border: none;
-          color: white;
+          color: var(--color-text);
           cursor: pointer;
           font-size: 14px;
           font-weight: bold;
@@ -66,7 +67,7 @@ const useCodeBlockHeader = () => {
         .code-header .copied-btn {
           background: none;
           border: none;
-          color: white;
+          color: var(--color-text);
           font-size: 14px;
           font-weight: bold;
           transition: opacity 0.2s ease-in-out;

--- a/src/hooks/useCodeBlockHeader.ts
+++ b/src/hooks/useCodeBlockHeader.ts
@@ -60,7 +60,16 @@ const useCodeBlockHeader = () => {
         }
 
         .code-header .copy-btn:hover {
-          opacity: 0.7;
+          opacity: 0.5;
+        }
+
+        .code-header .copied-btn {
+          background: none;
+          border: none;
+          color: white;
+          font-size: 14px;
+          font-weight: bold;
+          transition: opacity 0.2s ease-in-out;
         }
       `
       document.head.appendChild(style)
@@ -84,11 +93,27 @@ const useCodeBlockHeader = () => {
       `
 
       const copyButton = header.querySelector(".copy-btn") as HTMLButtonElement
+      let isThrottled = false
+
       copyButton.addEventListener("click", () => {
+        if (isThrottled) return
+        isThrottled = true
+
         const codeElement = pre.querySelector("code")
         if (codeElement) {
-            const codeText = codeElement.innerText
-            navigator.clipboard.writeText(codeText)
+          const codeText = codeElement.innerText
+          navigator.clipboard.writeText(codeText).then(() => {
+            copyButton.textContent = "Copied!"
+            copyButton.classList.add("copied-btn")
+            copyButton.classList.remove("copy-btn")
+
+            setTimeout(() => {
+              copyButton.textContent = "Copy"
+              copyButton.classList.add("copy-btn")
+              copyButton.classList.remove("copie-btn")
+              isThrottled = false
+            }, 1500)
+          })
         }
       })
 

--- a/src/hooks/useCodeBlockHeader.ts
+++ b/src/hooks/useCodeBlockHeader.ts
@@ -24,8 +24,8 @@ const useCodeBlockHeader = () => {
 
         .code-header .btn {
           border-radius: 50%;
-          width: 15px;
-          height: 15px;
+          width: 12px;
+          height: 12px;
           margin-right: 5px;
         }
 

--- a/src/hooks/useCodeBlockHeader.ts
+++ b/src/hooks/useCodeBlockHeader.ts
@@ -1,0 +1,9 @@
+import { useEffect } from "react"
+
+const useCodeBlockHeader = () => {
+  useEffect(() => {
+    console.log("useCodeBlockHeader useEffect 실행됨")
+  }, [])
+}
+
+export default useCodeBlockHeader

--- a/src/hooks/useCodeBlockHeader.ts
+++ b/src/hooks/useCodeBlockHeader.ts
@@ -7,16 +7,14 @@ const useCodeBlockHeader = () => {
       style.id = "code-header-style"
       style.innerHTML = `
         .code-header {
-          position: relative;
-          top: 0;
-          left: 0;
-          right: 0;
+          position: sticky;
+          left: 0px;
+          width: 100%;
           display: flex;
           align-items: center;
           padding: 10px 14px;
           background-color: #434041;
           border-radius: 8px 8px 0 0;
-          z-index: 10;
         }
 
         .code-header .btn {
@@ -42,7 +40,7 @@ const useCodeBlockHeader = () => {
     }
 
     document.querySelectorAll("pre.grvsc-container").forEach((pre) => {
-      if (pre.previousElementSibling?.classList.contains("code-header")) return
+      if (pre.querySelector(".code-header")) return
 
       const header = document.createElement("div")
       header.className = "code-header"
@@ -52,7 +50,7 @@ const useCodeBlockHeader = () => {
         <span class="green btn"></span>
       `
 
-      pre.parentNode?.insertBefore(header, pre)
+      pre.insertBefore(header, pre.firstChild)
     })
   }, [])
 }

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -70,6 +70,7 @@ const GlobalStyle = createGlobalStyle`
       --color-post-background: #ffffff;
       --color-card: #ffffff;
       --color-code: #f2f2f2;
+      --color-code-header: #e4e4e4;
       --color-code-block: #fafafa;
       --color-code-highlight: rgba(0, 0, 0, 0.05);
       --color-code-highlight-border: rgba(0, 0, 0, 0.2);
@@ -106,6 +107,7 @@ const GlobalStyle = createGlobalStyle`
       --color-post-background: #1c1c1c;
       --color-card: #2c2c2c;
       --color-code: #3a3a3a;
+      --color-code-header: #434041;
       --color-code-block: #242424;
       --color-code-highlight: rgba(255, 255, 255, 0.05);
       --color-code-highlight-border: rgba(255, 255, 255, 0.2);

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -193,30 +193,30 @@ const Markdown = styled.article<{ rhythm: (typeof typography)["rhythm"] }>`
     border-radius: 8px;
   }
 
-  pre::before {
-    content: "";
-    display: flex;
-    align-items: center;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 2rem;
-    background-color: #434041;
-    border-bottom: 1px solid #3c3c3c;
-  }
+  // pre::before {
+  //   content: "";
+  //   display: flex;
+  //   align-items: center;
+  //   position: absolute;
+  //   top: 0;
+  //   left: 0;
+  //   right: 0;
+  //   height: 2rem;
+  //   background-color: #434041;
+  //   border-bottom: 1px solid #3c3c3c;
+  // }
 
-  pre::after {
-    content: "";
-    position: absolute;
-    top: 0.6rem;
-    left: 1.0rem;
-    width: 0.75rem;
-    height: 0.75rem;
-    border-radius: 50%;
-    background-color: #f5655b;
-    box-shadow: 1.1rem 0 0 #f6bd3b, 2.2rem 0 0 #43c645;
-  }
+  // pre::after {
+  //   content: "";
+  //   position: absolute;
+  //   top: 0.6rem;
+  //   left: 1.0rem;
+  //   width: 0.75rem;
+  //   height: 0.75rem;
+  //   border-radius: 50%;
+  //   background-color: #f5655b;
+  //   box-shadow: 1.1rem 0 0 #f6bd3b, 2.2rem 0 0 #43c645;
+  // }
 
   pre {
     counter-reset: line-number;

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -184,6 +184,68 @@ const Markdown = styled.article<{ rhythm: (typeof typography)["rhythm"] }>`
     font-size: 85%;
     border-radius: 3px;
   }
+
+  /* mac 스타일 코드블럭 적용 */
+  pre {
+    position: relative;
+    padding-top: 3rem;
+    background-color: var(--color-code-block);
+    border-radius: 8px;
+  }
+
+  pre::before {
+    content: "";
+    display: flex;
+    align-items: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2rem;
+    background-color: #434041;
+    border-bottom: 1px solid #3c3c3c;
+  }
+
+  pre::after {
+    content: "";
+    position: absolute;
+    top: 0.6rem;
+    left: 1.0rem;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+    background-color: #f5655b;
+    box-shadow: 1.1rem 0 0 #f6bd3b, 2.2rem 0 0 #43c645;
+  }
+
+  pre {
+    counter-reset: line-number;
+  }
+
+  pre code {
+    position: relative;
+    padding-left: 0.7rem;
+  }
+
+  pre code > * {
+    display: block;
+    line-height: 1.5;
+    counter-increment: line-number;
+  }
+
+  pre code > *::before {
+    content: counter(line-number);
+    position: absolute;
+    left: 0;
+    width: 2rem;
+    text-align: right;
+    padding-right: 0.5rem;
+    color: #757575;
+  }
+
+  .grvsc-source {
+    padding-left: 2.5rem;
+  }
 `
 
 export default Markdown

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -188,35 +188,10 @@ const Markdown = styled.article<{ rhythm: (typeof typography)["rhythm"] }>`
   /* mac 스타일 코드블럭 적용 */
   pre {
     position: relative;
-    padding-top: 3rem;
+    padding-top: 0;
     background-color: var(--color-code-block);
     border-radius: 8px;
   }
-
-  // pre::before {
-  //   content: "";
-  //   display: flex;
-  //   align-items: center;
-  //   position: absolute;
-  //   top: 0;
-  //   left: 0;
-  //   right: 0;
-  //   height: 2rem;
-  //   background-color: #434041;
-  //   border-bottom: 1px solid #3c3c3c;
-  // }
-
-  // pre::after {
-  //   content: "";
-  //   position: absolute;
-  //   top: 0.6rem;
-  //   left: 1.0rem;
-  //   width: 0.75rem;
-  //   height: 0.75rem;
-  //   border-radius: 50%;
-  //   background-color: #f5655b;
-  //   box-shadow: 1.1rem 0 0 #f6bd3b, 2.2rem 0 0 #43c645;
-  // }
 
   pre {
     counter-reset: line-number;
@@ -224,6 +199,7 @@ const Markdown = styled.article<{ rhythm: (typeof typography)["rhythm"] }>`
 
   pre code {
     position: relative;
+    padding-top: 1rem;
     padding-left: 0.7rem;
   }
 

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -10,6 +10,7 @@ import Category from "~/src/styles/category"
 import DateTime from "~/src/styles/dateTime"
 import Markdown from "~/src/styles/markdown"
 import { rhythm } from "~/src/styles/typography"
+import useCodeBlockHeader from "../hooks/useCodeblockHeader"
 
 const BlogPost: React.FC<PageProps<Queries.Query>> = ({ data }) => {
   const { markdownRemark } = data
@@ -20,6 +21,8 @@ const BlogPost: React.FC<PageProps<Queries.Query>> = ({ data }) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     thumbnail &&
     thumbnail?.childImageSharp?.gatsbyImageData!.images!.fallback!.src
+
+  useCodeBlockHeader()
 
   return (
     <Layout>


### PR DESCRIPTION
## 기존

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/d4071f63-ed0a-41d0-b03d-9734acdd7f8c" />

### Features

- [x] 좌측에 line number 표시
- [x] 우측에 copy 버튼 구현
- [x] 상단에 어떤 언어인지 표기
- [x] 라이트모드/다크모드 대응

## 결과

<img width="677" alt="image" src="https://github.com/user-attachments/assets/26d6879e-8061-41f8-8faf-46b8bf01956e" />

### 참고

- https://guiyomi.tistory.com/132