### PR TITLE
[Feat] post-width 조정

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -94,6 +94,10 @@ const markdownPlugins = [
           resolve: "gatsby-remark-images",
           options: {
             linkImagesToOriginal: false,
+            maxWidth: 768,
+            quality: 100,
+            withWebp: true,
+            wrapperStyle: "max-width: 768px !important;"
           },
         },
         {

--- a/src/components/postGrid/card/centeredImg.tsx
+++ b/src/components/postGrid/card/centeredImg.tsx
@@ -21,6 +21,7 @@ const CenteredImg: React.FC<CenteredImgProperties> = ({ src }) => {
             id
             gatsbyImageData(
               layout: CONSTRAINED
+              width: 768
               aspectRatio: 1.77
               placeholder: BLURRED
             )

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -9,7 +9,7 @@ const GlobalStyle = createGlobalStyle`
 
     --width: 980px;
     --min-width: 320px;
-    --post-width: 650px;
+    --post-width: 768px;
     --nav-height: 54px;
     --comment-min-height: 284px;
     --footer-height: 60px;

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -201,6 +201,7 @@ const Markdown = styled.article<{ rhythm: (typeof typography)["rhythm"] }>`
     position: relative;
     padding-top: 1rem;
     padding-left: 0.7rem;
+    font-size: 0.8rem;
   }
 
   pre code > * {


### PR DESCRIPTION
### Tasks

- [x] post-width 값을 650px에서 768xp로 조정
- [x] 변경에 따른 이미지 크기 조정
- [x] 변경에 따른 코드블럭 폰트 사이즈 조정

### 변경 전

<img width="1366" alt="image" src="https://github.com/user-attachments/assets/0ad216ab-5b97-47bb-af28-a7866c99adf4" />

### 변경 후

<img width="1366" alt="image" src="https://github.com/user-attachments/assets/8dd1e3c4-d64f-4d7f-85d1-c633182854e7" />
